### PR TITLE
Fix encoding of certain characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,19 +197,23 @@ fn encode_str(buf: &mut String, s: &str) {
     #[inline(never)]
     fn slow_path(buf: &mut String, s: &str) {
         for c in s.chars() {
-            let b = c as u8;
-            match b {
-                b'\\' | b'"' => push_escape(buf, c),
-                b'\n' => push_escape(buf, 'n'),
-                b'\r' => push_escape(buf, 'r'),
-                b'\t' => push_escape(buf, 't'),
-                0..=0x1F | 0x7F..=0x9F => {
-                    push_escape(buf, 'u');
-                    buf.push_str("00");
-                    buf.push(hex(b & 0xF));
-                    buf.push(hex(b >> 4));
+            if (c as u32) < 256 {
+                let b = c as u8;
+                match b {
+                    b'\\' | b'"' => push_escape(buf, c),
+                    b'\n' => push_escape(buf, 'n'),
+                    b'\r' => push_escape(buf, 'r'),
+                    b'\t' => push_escape(buf, 't'),
+                    0..=0x1F | 0x7F..=0x9F => {
+                        push_escape(buf, 'u');
+                        buf.push_str("00");
+                        buf.push(hex(b >> 4));
+                        buf.push(hex(b & 0xF));
+                    }
+                    _ => buf.push(c),
                 }
-                _ => buf.push(c),
+            } else {
+                buf.push(c)
             }
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,7 +30,8 @@ fn string_escaping() {
             .string(" \r\n\t\\ \\r\\n\\t")
             .string("❤😂")
             .string("\x00\x07\x1F\x20\x7E\x7F\u{80}\u{9f}!")
-            .string("\x7F!");
+            .string("\x7F!")
+            .string("Ċ");
     }
     let strings = buf.replace(|c: char| "[],".contains(c), "\n");
     let expected = r#"
@@ -40,9 +41,10 @@ fn string_escaping() {
 "\\"
 "hello world"
 " \r\n\t\\ \\r\\n\\t"
-"❤\u0020"
-"\u0000\u0070\u00F1 ~\u00F7\u0008\u00F9!"
-"\u00F7!"
+"❤😂"
+"\u0000\u0007\u001F ~\u007F\u0080\u009F!"
+"\u007F!"
+"Ċ"
 "#;
 
     assert_eq!(strings, expected);


### PR DESCRIPTION
Thanks for this library!

I was using write-json and noticed it had problems encoding CJK name characters. The existing tests cover this case, they just unfortunately test the wrong output.